### PR TITLE
Use https in repo files by default

### DIFF
--- a/rdo-release.repo
+++ b/rdo-release.repo
@@ -1,6 +1,6 @@
 [openstack-kilo]
 name=OpenStack Kilo Repository
-baseurl=http://repos.fedorapeople.org/repos/openstack/openstack-kilo/%FDIST%%RELEASEVER%/
+baseurl=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/%FDIST%%RELEASEVER%/
 skip_if_unavailable=0
 enabled=1
 gpgcheck=1

--- a/rdo-testing.repo
+++ b/rdo-testing.repo
@@ -1,6 +1,6 @@
 [openstack-kilo-testing]
 name=OpenStack Kilo Testing
-baseurl=http://repos.fedorapeople.org/repos/openstack/openstack-kilo/testing/%FDIST%%RELEASEVER%/
+baseurl=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/testing/%FDIST%%RELEASEVER%/
 skip_if_unavailable=0
 gpgcheck=0
 enabled=0


### PR DESCRIPTION
While for the release repository we do have RPM GPG checking enabled,
there are various attacks one can mount if one controls unsigned
repodata; http://theupdateframework.com/ talks about that.

Fedora does set up a redirect, but this ensures we use it from
the start for stronger security.
