### PR TITLE
fix the repo address

### DIFF
--- a/rdo-release.repo
+++ b/rdo-release.repo
@@ -1,6 +1,6 @@
 [openstack-kilo]
 name=OpenStack Kilo Repository
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-kilo/
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-kilo/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud

--- a/rdo-testing.repo
+++ b/rdo-testing.repo
@@ -1,5 +1,5 @@
 [openstack-kilo-testing]
 name=OpenStack Kilo Testing
-baseurl=http://buildlogs.centos.org/centos/$releasever/cloud/$basearch/openstack-kilo/
+baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-kilo/
 gpgcheck=0
 enabled=0


### PR DESCRIPTION
On redhat 7.1, after ran "yum -y install https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm",  it failed to install openstack-packstack. 
The root cause is that repo address is wrong.
http://mirror.centos.org/centos/**7Server**/cloud/x86_64/openstack-kilo/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found

Please look at following detailed information.
[root@rhel etc]# yum install -y openstack-packstack
Loaded plugins: product-id, subscription-manager
http://mirror.centos.org/centos/7Server/cloud/x86_64/openstack-kilo/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
Trying other mirror.

When I change it to http://mirror.centos.org/centos/7/cloud/x86_64/openstack-kilo/repodata/repomd.xml, it works.

According to other release, for example: liberty's address "baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-liberty/", 
So I replease the "$releasever" to "7".

 One of the configured repositories failed (OpenStack Kilo Repository),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

```
 1. Contact the upstream for the repository and get them to fix the problem.

 2. Reconfigure the baseurl/etc. for the repository, to point to a working
    upstream. This is most often useful if you are using a newer
    distribution release than is supported by the repository (and the
    packages for the previous distribution release still work).

 3. Disable the repository, so yum won't use it by default. Yum will then
    just ignore the repository until you permanently enable it again or use
    --enablerepo for temporary usage:

        yum-config-manager --disable openstack-kilo

 4. Configure the failing repository to be skipped, if it is unavailable.
    Note that yum will try to contact the repo. when it runs most commands,
    so will have to try and fail each time (and thus. yum will be be much
    slower). If it is a very temporary problem though, this is often a nice
    compromise:

        yum-config-manager --save --setopt=openstack-kilo.skip_if_unavailable=true
```

failure: repodata/repomd.xml from openstack-kilo: [Errno 256] No more mirrors to try.
http://mirror.centos.org/centos/7Server/cloud/x86_64/openstack-kilo/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
