### PR TITLE
Set proper gpgkey for Virt SIG repos

### DIFF
--- a/rdo-qemu-ev.repo
+++ b/rdo-qemu-ev.repo
@@ -3,11 +3,11 @@ name=RDO CentOS-7 - QEMU EV
 baseurl=http://mirror.centos.org/centos/7/virt/$basearch/kvm-common/
 gpgcheck=1
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization-RDO
 
 [rdo-qemu-ev-test]
 name=RDO CentOS-7 - QEMU EV Testing
 baseurl=http://buildlogs.centos.org/centos/7/virt/$basearch/kvm-common/
 gpgcheck=1
 enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization-RDO


### PR DESCRIPTION
The file name is using the gpgkey file name from the
centos-release-qemu-ev package, not the one included in rdo-release.
