### PR TITLE
Using '$releasever' variable breaks RHEL

### DIFF
--- a/rdo-release.repo
+++ b/rdo-release.repo
@@ -1,7 +1,7 @@
 [openstack-stein]
 name=OpenStack Stein Repository
 #baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=cloud-openstack-stein
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=cloud-openstack-stein
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud

--- a/rdo-release.spec
+++ b/rdo-release.spec
@@ -1,6 +1,6 @@
 Name:           rdo-release
 Version:        stein
-Release:        1
+Release:        2
 Summary:        RDO repository configuration
 
 Group:          System Environment/Base
@@ -36,6 +36,9 @@ install -Dpm 644 %{SOURCE103} %{buildroot}%{_sysconfdir}/pki/rpm-gpg
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-*
 
 %changelog
+* Wed May 22 2019 Arun S A G <sagarun AT gmail.com> - stein-2
+- Fix breakage in RHEL
+
 * Tue Apr 30 2019 Alfredo Moralejo <amoralej AT redhat.com> - stein-1
 - first stable release and general availability of RDO Stein
 


### PR DESCRIPTION
The yum variable '$releasever' resolves to 7Server in RHEL7. However
mirrorlist.centos.org doesn't recognize 7Server. It only knows about
releasever '7'. So fix the mirrorlist to directly use '7' instead of
yum variable.

Success: curl "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=cloud-openstack-stein"
Fail: curl "http://mirrorlist.centos.org/?release=7Server&arch=x86_64&repo=cloud-openstack-stein"
Fail: curl "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-stein"